### PR TITLE
fix calls to mem.split

### DIFF
--- a/known-folders.zig
+++ b/known-folders.zig
@@ -146,7 +146,7 @@ fn getPathXdg(allocator: *std.mem.Allocator, arena: *std.heap.ArenaAllocator, fo
         _ = user_dirs.readAll(&read) catch null orelse break :block;
         const start = folder_spec.env.name.len + "=\"$HOME".len;
 
-        var line_it = std.mem.split(&read, "\n");
+        var line_it = std.mem.split(u8, &read, "\n");
         while (line_it.next()) |line| {
             if (std.mem.startsWith(u8, line, folder_spec.env.name)) {
                 const end = line.len - 1;


### PR DESCRIPTION
The API changed since https://github.com/ziglang/zig/commit/05fd20dc104b3654ce9c5d7a22a2bff66a940dba