### PR TITLE
`c_void` -> `anyopaque`

### DIFF
--- a/known-folders.zig
+++ b/known-folders.zig
@@ -68,7 +68,7 @@ pub fn getPath(allocator: std.mem.Allocator, folder: KnownFolder) Error!?[]const
                         &dir_path_ptr,
                     )) {
                         std.os.windows.S_OK => {
-                            defer std.os.windows.ole32.CoTaskMemFree(@ptrCast(*c_void, dir_path_ptr));
+                            defer std.os.windows.ole32.CoTaskMemFree(@ptrCast(*anyopaque, dir_path_ptr));
                             const global_dir = std.unicode.utf16leToUtf8Alloc(allocator, std.mem.span(dir_path_ptr)) catch |err| switch (err) {
                                 error.UnexpectedSecondSurrogateHalf => return null,
                                 error.ExpectedSecondSurrogateHalf => return null,


### PR DESCRIPTION
ziglang/zig@9f9f215305389c08a21730859982b68bf2681932