### PR TITLE
Fix build with zig 0.9.0

### DIFF
--- a/known-folders.zig
+++ b/known-folders.zig
@@ -68,7 +68,7 @@ pub fn getPath(allocator: std.mem.Allocator, folder: KnownFolder) Error!?[]const
                         &dir_path_ptr,
                     )) {
                         std.os.windows.S_OK => {
-                            defer std.os.windows.ole32.CoTaskMemFree(@ptrCast(*c_void, dir_path_ptr));
+                            defer std.os.windows.ole32.CoTaskMemFree(@ptrCast(*anyopaque, dir_path_ptr));
                             const global_dir = std.unicode.utf16leToUtf8Alloc(allocator, std.mem.span(dir_path_ptr)) catch |err| switch (err) {
                                 error.UnexpectedSecondSurrogateHalf => return null,
                                 error.ExpectedSecondSurrogateHalf => return null,


### PR DESCRIPTION
Zig 0.9.0 has been released, and `c_void` has been renamed to `anyopaque`.