### PR TITLE
scm, fix: Update build to use `b.path`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,6 +2,6 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     _ = b.addModule("known-folders", .{
-        .root_source_file = .{ .path = "known-folders.zig" },
+        .root_source_file = b.path("known-folders.zig"),
     });
 }


### PR DESCRIPTION
Necessary for dependent `ZLS` to build on latest Zig master.