### PR TITLE
Fixup deprecated utf16leToUtf8Alloc

### DIFF
--- a/known-folders.zig
+++ b/known-folders.zig
@@ -81,7 +81,7 @@ pub fn getPath(allocator: std.mem.Allocator, folder: KnownFolder) Error!?[]const
                     )) {
                         std.os.windows.S_OK => {
                             defer funcs.CoTaskMemFree(@ptrCast(dir_path_ptr));
-                            const global_dir = std.unicode.utf16leToUtf8Alloc(allocator, std.mem.span(dir_path_ptr)) catch |err| switch (err) {
+                            const global_dir = std.unicode.utf16LeToUtf8Alloc(allocator, std.mem.span(dir_path_ptr)) catch |err| switch (err) {
                                 error.UnexpectedSecondSurrogateHalf => return null,
                                 error.ExpectedSecondSurrogateHalf => return null,
                                 error.DanglingSurrogateHalf => return null,


### PR DESCRIPTION
This requires at least 0.14.0-dev.36+82a934bb9